### PR TITLE
Fixing the bug of data dependency

### DIFF
--- a/src/main/java/org/konveyor/dgi/utils/Graph2JSON.java
+++ b/src/main/java/org/konveyor/dgi/utils/Graph2JSON.java
@@ -58,22 +58,18 @@ public class Graph2JSON {
         int dfsNumber = 0;
         Map<Statement,Integer> dfsFinish = HashMapFactory.make();
         Iterator<Statement> search = DFS.iterateFinishTime(sdg, entryPoints.get());
-        
+       
+        while (search.hasNext()) {
+            dfsFinish.put(search.next(), dfsNumber++);
+        }
+
         // This is a reverse DFS search (or entry time first search)
         int reverseDfsNumber = 0;
         Map<Statement,Integer> dfsStart = HashMapFactory.make();
         Iterator<Statement> reverseSearch = DFS.iterateDiscoverTime(sdg, entryPoints.get());
-       
-        while (search.hasNext() && reverseSearch.hasNext()) {
-            Statement s = search.next();
-        	if (s != null) {
-        		dfsFinish.put(s, dfsNumber++);	
-        	}
-
-        	Statement r = reverseSearch.next();
-        	if (r != null) {
-        		dfsFinish.put(r, reverseDfsNumber++);	
-        	}
+        
+        while (reverseSearch.hasNext()) {
+            dfsStart.put(reverseSearch.next(), reverseDfsNumber++);
         }
 
         // Populate graph


### PR DESCRIPTION
I am reversing the changes over the loops I have done before. The cost that we saved by having just one loop was not worth the additional problems we found. Even by fixing the typo in `dfsStart` and replacing the `&&` by `||` in the while loop, there are a few differences in the output file when compared to the two separated loops.